### PR TITLE
Replaced ec2_facts with ec2_metadata_facts.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   tags: install_dependencies
 
 - name: Get Instance Metadata 
-  action: ec2_facts
+  action: ec2_metadata_facts
 
 - name: Fetch the CodeDeploy install script
   get_url:


### PR DESCRIPTION
## Description:
Replaced deprecated `ec2_facts` with `ec2_metadata_facts`.

## Issue: 
I've got a fatal error by running the tasks due to the `ec2_facts` is removed from ansible 2.8.

```
[DEPRECATION WARNING]: ec2_facts is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in a future release. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
fatal: [ec2-52-62-55-198.ap-southeast-2.compute.amazonaws.com]: FAILED! => {"changed": false, "msg": "This module has been removed.  The module documentation for Ansible-2.6 may contain hints for porting"}
```